### PR TITLE
Add support for splitting on checkpoints

### DIFF
--- a/superliminal.asl
+++ b/superliminal.asl
@@ -109,7 +109,7 @@ init
         vars.cp_name = "";
         vars.old_cp_name = "";
 
-        if(settings["split_on_cp"]) {
+        if (settings["split_on_cp"]) {
             vars.split_on_cp = true;
             print("Splitting on checkpoints");
         }
@@ -135,7 +135,7 @@ update
         vars.split_on_cp = settings["split_on_cp"];
 
         vars.old_cp_name = vars.cp_name;
-        if(current.checkpointNamePtr != 0 && current.checkpointNamePtr != old.checkpointNamePtr) {
+        if (current.checkpointNamePtr != 0 && current.checkpointNamePtr != old.checkpointNamePtr) {
             vars.cp_name = memory.ReadString((IntPtr)(current.checkpointNamePtr + 0x14), 256);
         }
     }


### PR DESCRIPTION
This pull request adds the following feature to the repo:

* An option "split on checkpoints" was added to the setting menu. The auto-splitter can now split on checkpoints, rather than chapters. This could be used with split files like [this](https://github.com/EtaoinWu/SuperliminalASL/blob/main/Superliminal%20-%20subsplits.lss).