### PR TITLE
feat: an option for skipping the checkpoint `_ParkingLot`.

### DIFF
--- a/superliminal.asl
+++ b/superliminal.asl
@@ -88,7 +88,7 @@ startup
     settings.SetToolTip("split_on_cp", "Use this with a split file that supports checkpoints.");
 
     settings.Add("skip_ParkingLot", false, "Skip checkpoint \"_ParkingLot\"");
-    settings.SetToolTip("skip_ParkingLot", "Skips the last checkpoint in Labyrinth to avoid an error.");
+    settings.SetToolTip("skip_ParkingLot", "Skips the last CP in Labyrinth to avoid an inconsistent CP skip.");
 }
 
 init

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -87,8 +87,8 @@ startup
     settings.Add("split_on_cp", false, "Split on checkpoints");
     settings.SetToolTip("split_on_cp", "Use this with a split file that supports checkpoints.");
 
-    settings.Add("skip_ParkingLot", false, "Skip checkpoint \"_ParkingLot\"");
-    settings.SetToolTip("skip_ParkingLot", "Skips the last CP in Labyrinth to avoid an inconsistent CP skip.");
+    settings.Add("split_ParkingLot", false, "Split on checkpoint \"_ParkingLot\"");
+    settings.SetToolTip("split_ParkingLot", "This CP is ignored by default to avoid an inconsistent CP skip.\nEnable this with caution.");
 }
 
 init
@@ -280,7 +280,7 @@ split
         && current.checkpointNamePtr != 0 
         && !vars.cp_name.Equals(vars.old_cp_name)
         && !vars.cp_name.Equals("")
-        && !(settings["skip_ParkingLot"] && vars.cp_name.Equals("_ParkingLot"))) {
+        && (settings["split_ParkingLot"] || !vars.cp_name.Equals("_ParkingLot"))) {
         checkpointUpdated = true;
     }
 

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -121,7 +121,8 @@ init
     vars.cp_name = "";
     vars.old_cp_name = "";
 
-    if (settings["split_on_cp"]) {
+    if (settings["split_on_cp"])
+    {
         vars.split_on_cp = true;
         print("Splitting on checkpoints");
     }
@@ -148,9 +149,8 @@ update
     vars.split_on_cp = settings["split_on_cp"];
 
     vars.old_cp_name = vars.cp_name;
-    if (current.checkpointNamePtr != 0 && current.checkpointNamePtr != old.checkpointNamePtr) {
+    if (current.checkpointNamePtr != 0 && current.checkpointNamePtr != old.checkpointNamePtr)
         vars.cp_name = memory.ReadString((IntPtr)(current.checkpointNamePtr + 0x14), 256);
-    }
 
     if (settings["il"])
     {
@@ -276,13 +276,11 @@ split
         }
     }
     
-    if (vars.split_on_cp
-        && current.checkpointNamePtr != 0 
-        && !vars.cp_name.Equals(vars.old_cp_name)
-        && !vars.cp_name.Equals("")
-        && (settings["split_ParkingLot"] || !vars.cp_name.Equals("_ParkingLot"))) {
-        checkpointUpdated = true;
-    }
+    if (vars.split_on_cp)
+        checkpointUpdated = current.checkpointNamePtr != 0 
+            && !vars.cp_name.Equals(vars.old_cp_name)
+            && !vars.cp_name.Equals("")
+            && (settings["split_ParkingLot"] || !vars.cp_name.Equals("_ParkingLot"))
 
     return enteredNextLevel || finalAlarmClicked || checkpointUpdated;
 }

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -86,6 +86,9 @@ startup
 
     settings.Add("split_on_cp", false, "Split on checkpoints");
     settings.SetToolTip("split_on_cp", "Use this with a split file that supports checkpoints.");
+
+    settings.Add("skip_ParkingLot", false, "Skip checkpoint \"_ParkingLot\"");
+    settings.SetToolTip("skip_ParkingLot", "Skips the last checkpoint in Labyrinth to avoid an error.");
 }
 
 init
@@ -276,7 +279,8 @@ split
     if (vars.split_on_cp
         && current.checkpointNamePtr != 0 
         && !vars.cp_name.Equals(vars.old_cp_name)
-        && !vars.cp_name.Equals("")) {
+        && !vars.cp_name.Equals("")
+        && !(settings["skip_ParkingLot"] && vars.cp_name.Equals("_ParkingLot"))) {
         checkpointUpdated = true;
     }
 


### PR DESCRIPTION
This pull request adds the following feature to the project:

* An option for skipping the checkpoint `_ParkingLot` was added. This is an workaround for a possible (inconsistent) CP skip, described in [the second CP skip mentioned here](https://github.com/EtaoinWu/SuperliminalASL/blob/main/README.md#skipping-cps).

This pull request has been tested on Steam ver. 1.10.2021.5.10.791, but the logic is simple enough to be believed to work on all versions.