### PR TITLE
Added collectible splitting for game ver 2021

### DIFF
--- a/superliminal.asl
+++ b/superliminal.asl
@@ -88,7 +88,7 @@ startup
     settings.SetToolTip("split_on_cp", "Use this with a split file that supports checkpoints.");
 
     settings.Add("skip_ParkingLot", false, "Skip checkpoint \"_ParkingLot\"");
-    settings.SetToolTip("skip_ParkingLot", "Skips the last checkpoint in Labyrinth to avoid an error.");
+    settings.SetToolTip("skip_ParkingLot", "Skips the last CP in Labyrinth to avoid an inconsistent CP skip.");
 }
 
 init

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -268,24 +268,6 @@ reset
 
 split
 {
-    Func<byte[],byte[],bool> arrayEquals = (a1, a2) => {
-        if (a1 == a2)
-            return true;
-
-        if (a1 == null || a2 == null)
-            return false;
-
-        if (a1.Length != a2.Length)
-            return false;
-
-        for (int i = 0; i < a1.Length; i++)
-        {
-            if (a1[i] != a2[i])
-                return false;
-        }
-        return true;
-    };
-
     bool enteredNextLevel = false;
     bool finalAlarmClicked = false;
     bool checkpointUpdated = false;
@@ -325,13 +307,13 @@ split
             const string Retrospect = "Assets/_Levels/_LiveFolder/ACT03/EndingMontage/EndingMontage_Live.unity";
             finalAlarmClicked = current.scene == Retrospect && current.alarmStopped;
             
-            bool diffFireAlarm = settings["split_on_FireAlarm"] && !arrayEquals(current.statusFireAlarm, old.statusFireAlarm);
-            bool diffExtinguisher = settings["split_on_Extinguisher"] && !arrayEquals(current.statusExtinguisher, old.statusExtinguisher);
-            bool diffConstellation = settings["split_on_Constellation"] && !arrayEquals(current.statusConstellation, old.statusConstellation);
-            bool diffChessPiece = settings["split_on_ChessPiece"] && !arrayEquals(current.statusChessPiece, old.statusChessPiece);
-            bool diffBlueprint = settings["split_on_Blueprint"] && !arrayEquals(current.statusBlueprint, old.statusBlueprint);
-            bool diffSodaType = settings["split_on_SodaType"] && !arrayEquals(current.statusSodaType, old.statusSodaType);
-            bool diffActualEggs = settings["split_on_ActualEggs"] && !arrayEquals(current.statusActualEggs, old.statusActualEggs);
+            bool diffFireAlarm = settings["split_on_FireAlarm"] && !Enumerable.SequenceEqual(current.statusFireAlarm, old.statusFireAlarm);
+            bool diffExtinguisher = settings["split_on_Extinguisher"] && !Enumerable.SequenceEqual(current.statusExtinguisher, old.statusExtinguisher);
+            bool diffConstellation = settings["split_on_Constellation"] && !Enumerable.SequenceEqual(current.statusConstellation, old.statusConstellation);
+            bool diffChessPiece = settings["split_on_ChessPiece"] && !Enumerable.SequenceEqual(current.statusChessPiece, old.statusChessPiece);
+            bool diffBlueprint = settings["split_on_Blueprint"] && !Enumerable.SequenceEqual(current.statusBlueprint, old.statusBlueprint);
+            bool diffSodaType = settings["split_on_SodaType"] && !Enumerable.SequenceEqual(current.statusSodaType, old.statusSodaType);
+            bool diffActualEggs = settings["split_on_ActualEggs"] && !Enumerable.SequenceEqual(current.statusActualEggs, old.statusActualEggs);
 
             collectibleUpdated |= diffFireAlarm;
             collectibleUpdated |= diffExtinguisher;

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -87,8 +87,8 @@ startup
     settings.Add("split_on_cp", false, "Split on checkpoints");
     settings.SetToolTip("split_on_cp", "Use this with a split file that supports checkpoints.");
 
-    settings.Add("skip_ParkingLot", false, "Skip checkpoint \"_ParkingLot\"");
-    settings.SetToolTip("skip_ParkingLot", "Skips the last CP in Labyrinth to avoid an inconsistent CP skip.");
+    settings.Add("split_ParkingLot", false, "Split on checkpoint \"_ParkingLot\"");
+    settings.SetToolTip("split_ParkingLot", "This CP is ignored by default to avoid an inconsistent CP skip.\nEnable this with caution.");
 }
 
 init
@@ -280,7 +280,7 @@ split
         && current.checkpointNamePtr != 0 
         && !vars.cp_name.Equals(vars.old_cp_name)
         && !vars.cp_name.Equals("")
-        && !(settings["skip_ParkingLot"] && vars.cp_name.Equals("_ParkingLot"))) {
+        && (settings["split_ParkingLot"] || !vars.cp_name.Equals("_ParkingLot"))) {
         checkpointUpdated = true;
     }
 

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -86,6 +86,9 @@ startup
 
     settings.Add("split_on_cp", false, "Split on checkpoints");
     settings.SetToolTip("split_on_cp", "Use this with a split file that supports checkpoints.");
+
+    settings.Add("skip_ParkingLot", false, "Skip checkpoint \"_ParkingLot\"");
+    settings.SetToolTip("skip_ParkingLot", "Skips the last checkpoint in Labyrinth to avoid an error.");
 }
 
 init
@@ -276,7 +279,8 @@ split
     if (vars.split_on_cp
         && current.checkpointNamePtr != 0 
         && !vars.cp_name.Equals(vars.old_cp_name)
-        && !vars.cp_name.Equals("")) {
+        && !vars.cp_name.Equals("")
+        && !(settings["skip_ParkingLot"] && vars.cp_name.Equals("_ParkingLot"))) {
         checkpointUpdated = true;
     }
 

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -106,7 +106,6 @@ startup
 
     settings.Add("split_ParkingLot", false, "Split on checkpoint \"_ParkingLot\"");
     settings.SetToolTip("split_ParkingLot", "This CP is ignored by default to avoid an inconsistent CP skip.\nEnable this with caution.");
-<<<<<<< HEAD
 
     settings.Add("split_on_FireAlarm", false, "Split on fire alarms");
     settings.Add("split_on_Extinguisher", false, "Split on fire extinguishers");
@@ -122,8 +121,6 @@ startup
     settings.SetToolTip("split_on_Blueprint", "Only works in game ver 2021");
     settings.SetToolTip("split_on_SodaType", "Only works in game ver 2021");
     settings.SetToolTip("split_on_ActualEggs", "Only works in game ver 2021");
-=======
->>>>>>> upstream/main
 }
 
 init
@@ -328,21 +325,21 @@ split
             const string Retrospect = "Assets/_Levels/_LiveFolder/ACT03/EndingMontage/EndingMontage_Live.unity";
             finalAlarmClicked = current.scene == Retrospect && current.alarmStopped;
             
-            bool diffFireAlarm = !arrayEquals(current.statusFireAlarm, old.statusFireAlarm);
-            bool diffExtinguisher = !arrayEquals(current.statusExtinguisher, old.statusExtinguisher);
-            bool diffConstellation = !arrayEquals(current.statusConstellation, old.statusConstellation);
-            bool diffChessPiece = !arrayEquals(current.statusChessPiece, old.statusChessPiece);
-            bool diffBlueprint = !arrayEquals(current.statusBlueprint, old.statusBlueprint);
-            bool diffSodaType = !arrayEquals(current.statusSodaType, old.statusSodaType);
-            bool diffActualEggs = !arrayEquals(current.statusActualEggs, old.statusActualEggs);
+            bool diffFireAlarm = settings["split_on_FireAlarm"] && !arrayEquals(current.statusFireAlarm, old.statusFireAlarm);
+            bool diffExtinguisher = settings["split_on_Extinguisher"] && !arrayEquals(current.statusExtinguisher, old.statusExtinguisher);
+            bool diffConstellation = settings["split_on_Constellation"] && !arrayEquals(current.statusConstellation, old.statusConstellation);
+            bool diffChessPiece = settings["split_on_ChessPiece"] && !arrayEquals(current.statusChessPiece, old.statusChessPiece);
+            bool diffBlueprint = settings["split_on_Blueprint"] && !arrayEquals(current.statusBlueprint, old.statusBlueprint);
+            bool diffSodaType = settings["split_on_SodaType"] && !arrayEquals(current.statusSodaType, old.statusSodaType);
+            bool diffActualEggs = settings["split_on_ActualEggs"] && !arrayEquals(current.statusActualEggs, old.statusActualEggs);
 
-            collectibleUpdated |= settings["split_on_FireAlarm"] && diffFireAlarm;
-            collectibleUpdated |= settings["split_on_Extinguisher"] && diffExtinguisher;
-            collectibleUpdated |= settings["split_on_Constellation"] && diffConstellation;
-            collectibleUpdated |= settings["split_on_ChessPiece"] && diffChessPiece;
-            collectibleUpdated |= settings["split_on_Blueprint"] && diffBlueprint;
-            collectibleUpdated |= settings["split_on_SodaType"] && diffSodaType;
-            collectibleUpdated |= settings["split_on_ActualEggs"] && diffActualEggs;
+            collectibleUpdated |= diffFireAlarm;
+            collectibleUpdated |= diffExtinguisher;
+            collectibleUpdated |= diffConstellation;
+            collectibleUpdated |= diffChessPiece;
+            collectibleUpdated |= diffBlueprint;
+            collectibleUpdated |= diffSodaType;
+            collectibleUpdated |= diffActualEggs;
         }
     }
     


### PR DESCRIPTION
This pull request adds the following features to the auto-splitter:

* The ability to create splits when a certain type of collectible is collected. Seven types of collectibles are available: fire alarms, fire extinguishers, constellations, chess pieces, blueprints, types of soda and literal Easter eggs.
* Seven check marks are added to the settings, each of which controlling whether a certain type of collectibles will trigger a split.

This feature has been tested by various members in the Discord community, including SAMrth and Hippienator.