### PR TITLE
fix: Version detection in legacy

### DIFF
--- a/superliminal.asl
+++ b/superliminal.asl
@@ -191,15 +191,7 @@ startup
 init
 {
     // check size of UnityPlayer.dll to determine version
-    long unitySize = 0;
-
-    for (int i = 0; i < modules.Length; i++)
-    {
-        if (modules[i].ModuleName == "UnityPlayer.dll")
-        {
-            unitySize = modules[i].ModuleMemorySize;
-        }
-    }
+    var unitySize = Array.Find(modules, m => m.ModuleName == "UnityPlayer.dll").ModuleMemorySize;
 
     if (unitySize == 25210880)
     {

--- a/superliminal.asl
+++ b/superliminal.asl
@@ -191,18 +191,28 @@ startup
 init
 {
     // check size of UnityPlayer.dll to determine version
-    if (modules[4].ModuleMemorySize == 25210880)
+    long unitySize = 0;
+
+    for (int i = 0; i < modules.Length; i++)
+    {
+        if (modules[i].ModuleName == "UnityPlayer.dll")
+        {
+            unitySize = modules[i].ModuleMemorySize;
+        }
+    }
+
+    if (unitySize == 25210880)
     {
         print("Using Hot Coffee Mod");
         version = "2019";
     }
-    else if (modules[4].ModuleMemorySize == 25563136 ||
-             modules[4].ModuleMemorySize == 24654280) // gog v1.10.2020.11.4
+    else if (unitySize == 25563136 ||
+             unitySize == 24654280) // gog v1.10.2020.11.4
     {
         print("Using in-game speedrun timer");
         version = "2020";
     }
-    else if (modules[4].ModuleMemorySize == 26968064)
+    else if (unitySize == 26968064)
     {
         print("Game Pass PC: Using scene filename and in-game speedrun timer");
         version = "GamePassPC2021";


### PR DESCRIPTION
As per discord:

> UnityPlayer isn't the 5th ([4]) module of the game, it's 6th instead

To fix this issue forever, a new mechanism to obtain the module size of `UnityPlayer.dll` is proposed. The pull request iterates through all modules of the game and find the exact `UnityPlayer.dll` module, instead of relying on the magic number `4`.